### PR TITLE
add ChangeVal interfact

### DIFF
--- a/kvSql.ServiceDefaults/JumpKV/ITableNode.cs
+++ b/kvSql.ServiceDefaults/JumpKV/ITableNode.cs
@@ -14,6 +14,8 @@ namespace kvSql.ServiceDefaults.BpTree
 
         bool ExistKey(object key);
 
+        bool ChangeVal(object key, object val);
+
         object? GetVal(object key);
     }
 
@@ -24,6 +26,8 @@ namespace kvSql.ServiceDefaults.BpTree
         bool DeteleKey(Tkey key);
 
         bool ExistKey(Tkey key);
+
+        bool ChangeVal(Tkey key, TVal val);
 
         TVal? GetVal(Tkey key);
     }

--- a/kvSql.ServiceDefaults/JumpKV/JumpNode.cs
+++ b/kvSql.ServiceDefaults/JumpKV/JumpNode.cs
@@ -75,6 +75,11 @@ namespace kvSql.ServiceDefaults.BpTree
             return ExistKey((TKey)key);
         }
 
+        public bool ChangeVal(object key, object val)
+        {
+            return ChangeVal((TKey)key, (TVal)val);
+        }
+
         public bool AddVal(TKey key, TVal val)
         {
             JumpNode<TKey, TVal>[] update = new JumpNode<TKey, TVal>[LeverMax + 1];
@@ -167,6 +172,27 @@ namespace kvSql.ServiceDefaults.BpTree
             }
             if (p.Next[0] != null && p.Next[0].Val.Keys.CompareTo(key) == 0)
             {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public bool ChangeVal(TKey key, TVal val)
+        {
+            JumpNode<TKey, TVal> p = head;
+            for (int i = LeverMax; i >= 0; i--)
+            {
+                while (p.Next[i] != null && p.Next[i].Val.Keys.CompareTo(key) < 0)
+                {
+                    p = p.Next[i];
+                }
+            }
+            if (p.Next[0] != null && p.Next[0].Val.Keys.CompareTo(key) == 0)
+            {
+                p.Next[0].Val.Values = val;
                 return true;
             }
             else


### PR DESCRIPTION
#### PR Classification
API 变更

#### PR Summary
在 `kvSql.ServiceDefaults.BpTree` 命名空间下添加了新方法以支持键值更新和获取操作。
- `ITableNode.cs` 文件中添加了 `ChangeVal` 和 `GetVal` 方法。
- `ITableNode.cs` 文件中泛型接口 `IJumpNode<Tkey, TVal>` 添加了 `ChangeVal` 和 `GetVal` 方法。
- `JumpNode.cs` 文件中实现了 `ChangeVal` 方法。
